### PR TITLE
feat:메인 메뉴에 조회수 높은 게시글 5개 가져옴

### DIFF
--- a/controller/Cindex.js
+++ b/controller/Cindex.js
@@ -1,6 +1,19 @@
+const { Board } = require('../models');
+
 // GET '/'
 // 메인 화면
-exports.index = (req, res) => {
+exports.index = async (req, res) => {
   // console.log(req.session.userInfo);
-  res.render("index", { session: req.session.userInfo });
+  // 조회수가 높은 차례대로 글 5개 전달
+  const rankBoard = await Board.findAll({
+    order: [['count', 'DESC']],
+    limit: 5,
+  });
+  console.log('rank >>>>>', rankBoard);
+  // rankBoard 사용 예시 : 게시글의 조회수 출력
+  // for (i = 0; i < rankBoard.length; i++) {
+  //   console.log('rankBoard.count = ', rankBoard[i].count);
+  // }
+
+  res.render('index', { session: req.session.userInfo, boards: rankBoard });
 };


### PR DESCRIPTION
Cindex.js에 get방식으로 '/'경로로 들어가면 db에서 조회수 높은 게시글 5개를 가져오는 기능을 추가했습니다.
boards라는 객체에 저장했습니다.
boards[i].tilte 이런 식으로 사용하면 됩니다. ( i : 0~4)