### PR TITLE
fix: 스터디 참가 신청 오류 수정

### DIFF
--- a/controller/Cstudy.js
+++ b/controller/Cstudy.js
@@ -223,6 +223,7 @@ exports.patchStudyApply = async (req, res) => {
     const checkUser = await StudyApply.findOne({
       where: {
         userSeq: userSeq,
+        studySeq: studySeq,
       },
     });
 


### PR DESCRIPTION
Cstudy.js
참가 신청 시 이미 참가 신청한 유저인지 확인할 때 userSeq로만 조회하고 있어 studySeq도 추가했습니다