### PR TITLE
fix ::: 게시글 검색/카테고리 검색/페이징 처리 버그 수정 완료

### DIFF
--- a/controller/Cboard.js
+++ b/controller/Cboard.js
@@ -25,7 +25,7 @@ exports.getBoard = async (req, res) => {
     req.session.boardInfo = {
       search: undefined,
       pageNum: pageNum,
-      category: undefined,
+      category: ['0', '1', '2', '3', '4', '5'], // 모든 카테고리 입력
     };
 
     const board = await Board.findAll({
@@ -74,19 +74,23 @@ exports.getBoardList = async (req, res) => {
   try {
     // 특정 게시글의 게시글 시퀀스, 검색어
     const { boardSeq, search, pageNum, category } = req.query;
+    console.log('###########################');
+    console.log(category);
+    console.log('###########################');
 
     // 1) 기존 검색어나 카테고리 정보가 다를 경우, 페이지 번호를 1로 설정
     // 배열 비교 및 값을 가지고 있는지 확인하는 방법
     // - 참고 : https://velog.io/@bepyan/JS-%EB%B0%B0%EC%97%B4%EB%A5%BC-%EB%B9%84%EA%B5%90%ED%95%98%EB%8A%94-%EB%B2%95)
-    function arraysEqual(arr1, arr2){
-      if(!arr1 || !arr2) return false; // 빈 배열이 아닌 undefined, null, '' 이면 false
-      if(arr1.length !== arr2.length) return false; // 길이가 같은지 먼저 비교
-      for(let i=0; i<arr1.length; ++i){ // 요소 값을 하나하나 비교
-        if(arr1[i] !== arr2[i]) return false;
+    function arraysEqual(arr1, arr2) {
+      if (!arr1 || !arr2) return false; // 빈 배열이 아닌 undefined, null, '' 이면 false
+      if (arr1.length !== arr2.length) return false; // 길이가 같은지 먼저 비교
+      for (let i = 0; i < arr1.length; ++i) {
+        // 요소 값을 하나하나 비교
+        if (arr1[i] !== arr2[i]) return false;
       }
 
       return true;
-    };
+    }
 
     if (
       search !== req.session.boardInfo.search ||
@@ -167,9 +171,9 @@ exports.getBoardList = async (req, res) => {
         comments: allComment,
       });
 
-    // ###########################################
-    // 2. 게시글 검색 / 카테고리 / 페이징 처리
-    // ###########################################
+      // ###########################################
+      // 2. 게시글 검색 / 카테고리 / 페이징 처리
+      // ###########################################
     } else {
       // 세션에 검색어가 없는 경우, '%%'로 전체 검색 설정
       const paramSearch = req.session.boardInfo.search

--- a/routes/board.js
+++ b/routes/board.js
@@ -45,7 +45,7 @@ const uploadConfig = multer({
 });
 
 router.get('/', controller.getBoard); // 게시글 조회 화면으로 이동
-router.get('/list', controller.getBoardList); // 게시글 검색 및 페이징 처리
+router.get('/list', controller.getBoardList); // 특정 게시글 조회 / 게시글 검색 / 카테고리 검색 / 페이징 처리
 router.delete('/remove', controller.deleteBoard); // 게시글 삭제 처리
 router.get('/register', controller.getRegister); // 게시글 등록 화면
 router.post(

--- a/static/js/listBoard.js
+++ b/static/js/listBoard.js
@@ -91,10 +91,39 @@ async function changePageNum(pageDiv) {
   // 해당 페이지 번호 클릭 -> 클릭한 this 객체가 pageDiv
   const pageNum = pageDiv.textContent;
 
+  // 선택된 카테고리
+  const categories = tagify.value;
+  // 요청을 위한 빈 배열
+  const getCategories = [];
+  // 태그 추가 이벤트 발생 전까지 있던 카테고리 배열에 추가
+  categories.forEach((category) => {
+    switch (category.value) {
+      case '웹':
+        getCategories.push(0);
+        break;
+      case '앱':
+        getCategories.push(1);
+        break;
+      case 'AI':
+        getCategories.push(2);
+        break;
+      case 'UI / UX':
+        getCategories.push(3);
+        break;
+      case '게임':
+        getCategories.push(4);
+        break;
+      case '기타':
+        getCategories.push(5);
+        break;
+    }
+  });
+
   // 해당 페이지에 해당하는 데이터 보내달라고 요청
   const res = await axios({
-    url: `/board/list?pageNum=${pageNum}`,
+    url: `/board/list`,
     method: 'get',
+    params: { pageNum: pageNum, category: getCategories },
   });
   let boards = res.data.data;
   updateElement(boards);
@@ -228,14 +257,15 @@ async function onAddTag() {
     method: 'get',
     params: { category: getCategories },
   });
-  if (res.data.board) {
-    updateElement(res.data.board);
+  console.log(res);
+  if (res.data.data) {
+    updateElement(res.data.data);
   }
   // 페이징 처리
   const boardPage = document.querySelector('.board_page');
   boardPage.innerHTML = '';
   const newDiv = document.createElement('div');
-  for (i = 0; i < Math.ceil(res.data.board.length / 10); i++) {
+  for (i = 0; i < Math.ceil(res.data.allBoardLen / 10); i++) {
     const pageDiv = document.createElement('div');
     pageDiv.setAttribute('onclick', 'changePageNum(this)');
     pageDiv.textContent = i + 1;
@@ -278,26 +308,27 @@ async function onRemoveTag() {
     method: 'get',
     params: { category: getCategories },
   });
-  if (res.data.board) {
-    const boards = res.data.board;
+  console.log(res);
+  if (res.data.data) {
+    const boards = res.data.data;
     const boardList = document.getElementById('boardList');
 
     boardList.innerHTML = ''; // 기존 목록을 비우고 검색 결과를 새로 표시
 
     boards.forEach((board) => {
-      console.log(board);
-      const count = board.board.count;
-      const title = board.board.title;
+      // console.log(board);
+      const count = board.count;
+      const title = board.title;
       const content =
-        board.board.content.length <= 180
-          ? board.board.content
-          : board.board.content.slice(0, 179) + '...';
-      const boardSeq = board.board.boardSeq;
-      const year = board.board.year;
-      const month = board.board.month;
-      const day = board.board.day;
+        board.content.length <= 180
+          ? board.content
+          : board.content.slice(0, 179) + '...';
+      const boardSeq = board.boardSeq;
+      const year = board.year;
+      const month = board.month;
+      const day = board.day;
       const boardLength = boards.length;
-      const study = board.category;
+      const study = board.study.category;
       let studyString;
       switch (study) {
         case 0:
@@ -375,7 +406,7 @@ async function onRemoveTag() {
       const year = board.year;
       const month = board.month;
       const day = board.day;
-      const study = board.category || board.board.category;
+      const study = board.category || board.study.category;
       let studyString;
       switch (study) {
         case 0:


### PR DESCRIPTION
1. 게시글 검색 시, if ~ else if ~ else 로 구분했던 것을 하나로 통일한 쿼리문으로 작성
2. 쿼리스트링으로 넘어오는 값 (boardSeq, search, pageNum, category)를 세션에 저장해서 관리 (req.session.boardInfo)
3. 프론트 버그 수정
    - tagify 라이브러리 사용 시, 카테고리를 추가하거나 없애는 경우 페이징 처리가 제대로 되지 않았던 점 수정
    - 쿼리문 수정으로 인해 변경된 변수명으로 수정
4. 카테고리나 검색어를 입력/수정하는 경우에는 검색된 건수에 상관없이 강제로 1페이지로 넘어가도록 수정

※ 프론트에서 수정해야하는 버그 존재 : 검색어 없을 때, 모든 카테고리가 검색됨
(Ex. 검색어로 검색 → '기타' 카테고리 삭제 → 검색어 제거 후 검색 → '기타' 카테고리가 등장)